### PR TITLE
Dazzle gives read/execute to others on Ubuntu 12.04 server

### DIFF
--- a/dazzle.sh
+++ b/dazzle.sh
@@ -180,6 +180,9 @@ create_project () {
     echo "  -> chown --recursive $DAZZLE_USER:$DAZZLE_GROUP $DAZZLE_HOME"
     chown --recursive $DAZZLE_USER:$DAZZLE_GROUP "$DAZZLE_HOME"
 
+    echo "  -> chmod --recursive o-rwx $DAZZLE_HOME/$1"
+    chmod --recursive o-rwx "$DAZZLE_HOME"/"$1"
+
     sleep 0.5
 
     echo


### PR DESCRIPTION
...and probably other servers, but I didn't test any. I was able to use my own user (not storage) to add a hosted project and download a complete (but read-only) copy of a project without using the storage user or adding the key to "authorized_keys".

I'm submitting a simple patch, but I'm far from a Linux permissions expert.

I didn't apply the change to the entire DAZZLE_HOME directory (like the user/group ownership currently are). That could cause creating a new project to break existing projects if they are counting on the current behaviour for some reason. I just removed read/write/execute for others on the new project directory.

This worked for me, I was no longer able to successfully add and download the files to a project without properly adding the key and connecting as storage.

It might also be a good idea (but probably not necessary) to change the umask for the storage user and ssh connections,  but I don't know if that varies between distributions. The Ubuntu .profile has a comment "for ssh logins, install and configure the libpam-umask package", but that sounds like it might be Debian/Ubuntu specific. 
