### PR TITLE
Update dazzle.sh - A few more file extentions that should not be compressed.

### DIFF
--- a/dazzle.sh
+++ b/dazzle.sh
@@ -168,7 +168,7 @@ create_project () {
     $GIT config --file "$DAZZLE_HOME/$1/config" receive.denyNonFastForwards true
 
     # Add list of files that Git should not compress
-    EXTENSIONS="jpg jpeg png tiff gif flac mp3 ogg oga avi mov mpg mpeg mkv ogv ogx webm zip gz bz bz2 rpm deb tgz rar ace 7z pak iso dmg"
+    EXTENSIONS="jpg jpeg png tiff gif psd xcf flac mp3 ogg oga avi mov mpg mpeg mkv ogv ogx webm zip gz bz xz 7z bz2 rpm deb tgz rar ace 7z pak msi iso dmg"
     for EXTENSION in $EXTENSIONS; do
       sleep 0.05
       echo -ne "  -> echo \"*.$EXTENSION -delta\" >> $DAZZLE_HOME/$1/info/attributes      \r"


### PR DESCRIPTION
Added a few extentions to the -deta extention list.
psd(Photoshop)
xcf(Gimp)
xz & 7z (Compression)
msi(Microsoft installer with compression)

Git was getting killed on  my vps when adding a new Sparkleshare client because of some large psd files.
Fixed by  adding .png to the -delta info list.